### PR TITLE
increase sleep before background change

### DIFF
--- a/start-turbovnc.sh
+++ b/start-turbovnc.sh
@@ -32,7 +32,7 @@ echo "starting novnc ${NOVNC_VERSION}"
 screen -dmS novnc bash -c '/usr/local/novnc/noVNC-${NOVNC_VERSION}/utils/novnc_proxy --vnc localhost:5901 --listen 5801 2>&1 | tee /tmp/novnc.log'
 
 # change background
-(sleep 5; xfconf-query -c xfce4-desktop -p $(xfconf-query -c xfce4-desktop -l | grep "workspace0/last-image") -s /usr/share/backgrounds/xfce/lcas.jpg > /dev/null 2>&1)&
+(sleep 30; xfconf-query -c xfce4-desktop -p $(xfconf-query -c xfce4-desktop -l | grep "workspace0/last-image") -s /usr/share/backgrounds/xfce/lcas.jpg > /dev/null 2>&1)&
 
 echo 
 echo "****************************************************************************************************************************************"


### PR DESCRIPTION
This pull request includes a small but important change to the `start-turbovnc.sh` script. The change modifies the delay for changing the background image from 5 seconds to 30 seconds to ensure the background change occurs after the desktop environment is fully loaded.

* [`start-turbovnc.sh`](diffhunk://#diff-2fc2a7a151d8b9d65a0286a583c60633f7c99b15fd9c9fe1da7271ea08e60d27L35-R35): Increased the sleep duration from 5 seconds to 30 seconds before changing the background image to ensure the desktop environment is fully loaded.