### PR TITLE
add cuda 11.8

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -20,11 +20,11 @@ jobs:
         fail-fast: false
         matrix:
           include:
+            - base_image: nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
+              push_tag: jammy-cuda11.8
+            
             - base_image: nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04
               push_tag: jammy-cuda12.2
-
-            # - base_image: nvidia/cuda:12.6.2-cudnn-devel-ubuntu22.04
-            #   push_tag: jammy-cuda12.6
 
             - base_image: nvidia/cuda:12.6.3-cudnn-devel-ubuntu24.04
               push_tag: noble-cuda12.6


### PR DESCRIPTION
This pull request includes updates to the Docker build workflow configuration in the `.github/workflows/docker-build.yaml` file. The changes primarily involve the addition and removal of specific base images and their corresponding tags.

Changes to Docker build workflow configuration:

* Added a new base image `nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04` with the tag `jammy-cuda11.8`.
* Removed the commented-out base image `nvidia/cuda:12.6.2-cudnn-devel-ubuntu22.04`.