### PR TITLE
Update docker-build.yaml

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -21,6 +21,9 @@ jobs:
         fail-fast: false
         matrix:
           include:
+            - base_image: westonrobot/ros:humble-ci
+              push_tag: westonrobot
+   
             - base_image: nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
               push_tag: jammy-cuda11.8
             


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/docker-build.yaml` file to update the Docker build matrix. The most important change is the addition of a new base image to the matrix.

Updates to Docker build matrix:

* [`.github/workflows/docker-build.yaml`](diffhunk://#diff-a894120de2d841cb7e1e40a5faee2225d8810cc3fe03ecd231b07322594fca1cR24-R26): Added `westonrobot/ros:humble-ci` as a new base image with the `push_tag` set to `westonrobot`.