### PR TITLE
update zenoh to 1.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ RUN mkdir -p /etc/ros/rosdep/sources.list.d/ && \
 
 ENV ROSDISTRO_INDEX_URL=https://raw.github.com/LCAS/rosdistro/master/index-v4.yaml
 
-ENV ZENOH_BRIDGE_VERSION=1.1.0
+ENV ZENOH_BRIDGE_VERSION=1.2.1
 RUN cd /tmp; \
     if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
       curl -L -O https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/releases/download/${ZENOH_BRIDGE_VERSION}/zenoh-plugin-ros2dds-${ZENOH_BRIDGE_VERSION}-aarch64-unknown-linux-gnu-standalone.zip; \


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change updates the `ZENOH_BRIDGE_VERSION` environment variable to a newer version.

* Updated `ZENOH_BRIDGE_VERSION` environment variable from `1.1.0` to `1.2.1` in `Dockerfile`.