### PR TITLE
Add Dockerfile for Selkies project and update build configuration

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -25,7 +25,7 @@ jobs:
               push_tag: westonrobot
               dockerfile: Dockerfile
    
-            - base_image: ghcr.io/selkies-project/nvidia-egl-desktop:24.04-20250629090949
+            - base_image: ghcr.io/linuxserver/baseimage-selkies:ubuntunoble
               push_tag: selkies-nvidia-24.04
               dockerfile: Dockerfile.selkies
    

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -25,7 +25,7 @@ jobs:
               push_tag: westonrobot
               dockerfile: Dockerfile
    
-            - base_image: ghcr.io/linuxserver/baseimage-selkies:ubuntunoble
+            - base_image: lscr.io/linuxserver/webtop:ubuntu-xfce
               push_tag: selkies-nvidia-24.04
               dockerfile: Dockerfile.selkies
    

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -23,19 +23,28 @@ jobs:
           include:
             - base_image: westonrobot/ros:humble-ci
               push_tag: westonrobot
+              dockerfile: Dockerfile
+   
+            - base_image: ghcr.io/selkies-project/nvidia-egl-desktop:24.04
+              push_tag: selkies-nvidia-24.04
+              dockerfile: Dockerfile.selkies
    
             - base_image: nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
               push_tag: jammy-cuda11.8
+              dockerfile: Dockerfile
 
             - base_image: nvidia/cuda:12.1.0-cudnn8-devel-ubuntu22.04
               push_tag: jammy-cuda12.1
+              dockerfile: Dockerfile
 
             - base_image: nvidia/cuda:12.2.2-cudnn8-devel-ubuntu22.04
               push_tag: jammy-cuda12.2
+              dockerfile: Dockerfile
 
             - base_image: nvidia/cuda:12.6.3-cudnn-devel-ubuntu24.04
               push_tag: noble-cuda12.6
-  
+              dockerfile: Dockerfile
+
     steps:
     - name: Node Js
       uses: actions/setup-node@v4
@@ -86,7 +95,7 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         context: .
-        file: ./Dockerfile
+        file: ./${{ matrix.dockerfile }}
         platforms: linux/amd64,linux/arm64
         push: true
         cache-from: type=registry,ref=lcas.lincoln.ac.uk/cache/${{ steps.docker_image_name.outputs.docker_image }}:${{ matrix.push_tag }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -25,7 +25,7 @@ jobs:
               push_tag: westonrobot
               dockerfile: Dockerfile
    
-            - base_image: ghcr.io/selkies-project/nvidia-egl-desktop:24.04
+            - base_image: ghcr.io/selkies-project/nvidia-egl-desktop:24.04-20250629090949
               push_tag: selkies-nvidia-24.04
               dockerfile: Dockerfile.selkies
    

--- a/Dockerfile.selkies
+++ b/Dockerfile.selkies
@@ -4,28 +4,6 @@ ARG BASE_IMAGE=lscr.io/linuxserver/webtop:ubuntu-xfce
 FROM ${BASE_IMAGE} AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
-
-# Install language
-RUN apt-get update ; \
-  apt-get upgrade -y && \
-  apt-get install -y --no-install-recommends \
-  locales \
-  && locale-gen en_US.UTF-8 \
-  && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
-  && rm -rf /var/lib/apt/lists/*
-ENV LANG=en_US.UTF-8
-
-# Install timezone
-RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
-  && export DEBIAN_FRONTEND=noninteractive \
-  && apt-get update ; \
-  apt-get install -y --no-install-recommends tzdata \
-  && dpkg-reconfigure --frontend noninteractive tzdata \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update; apt-get -y upgrade \
-    && rm -rf /var/lib/apt/lists/*
-
 # Install common programs
 RUN apt-get update; apt-get install -y --no-install-recommends \
     curl \
@@ -88,8 +66,8 @@ FROM lcas AS image_customisation
 #ENV CUSTOM_PORT=5801
 #ENV NO_FULL=1
 COPY lcas.png /lcas.png
-ENV WATERMARK_PNG=/lcas.png
-ENV WATERMARK_LOCATION=5
+#ENV WATERMARK_PNG=/lcas.png
+#ENV WATERMARK_LOCATION=5
 ENV TITLE="L-CAS Desktop Container"
 
 ###########################################

--- a/Dockerfile.selkies
+++ b/Dockerfile.selkies
@@ -78,7 +78,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
   # Add sudo support for the non-root user
   && apt-get update \
   && apt-get install -y --no-install-recommends sudo \
-  && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+  && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
   && chmod 0440 /etc/sudoers.d/$USERNAME \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.selkies
+++ b/Dockerfile.selkies
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/linuxserver/baseimage-selkies:ubuntunoble
+ARG BASE_IMAGE=lscr.io/linuxserver/webtop:ubuntu-xfce
 
 ###########################################
 FROM ${BASE_IMAGE} AS base
@@ -39,49 +39,10 @@ RUN apt-get update; apt-get install -y --no-install-recommends \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-
 # Prepare ROS2
 RUN add-apt-repository universe \
   && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
-
-################
-# Expose the nvidia driver to allow opengl 
-# Dependencies for glvnd and X11.
-################
-RUN apt-get update \
- && apt-get install -y -qq --no-install-recommends \
-  libglvnd0 \
-  libgl1 \
-  libglx0 \
-  libegl1 \
-  libxext6 \
-  libx11-6 \
-  && rm -rf /var/lib/apt/lists/*
-
-# Env vars for the nvidia-container-runtime.
-ENV NVIDIA_VISIBLE_DEVICES=all
-# enable all capabilities for the container
-# Explained here: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/1.10.0/user-guide.html#driver-capabilities
-ENV NVIDIA_DRIVER_CAPABILITIES=all
-ENV QT_X11_NO_MITSHM=1
-
-
-ARG USERNAME=ros
-ARG USER_UID=1001
-ARG USER_GID=$USER_UID
-
-# Create a non-root user
-RUN groupadd --gid $USER_GID $USERNAME \
-  && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
-  # Add sudo support for the non-root user
-  && apt-get update \
-  && apt-get install -y --no-install-recommends sudo \
-  && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
-  && chmod 0440 /etc/sudoers.d/$USERNAME \
-  && rm -rf /var/lib/apt/lists/*
-
 
 ###########################################
 FROM base AS lcas
@@ -101,7 +62,7 @@ RUN mkdir -p /etc/ros/rosdep/sources.list.d/ && \
 
 ENV ROSDISTRO_INDEX_URL=https://raw.github.com/LCAS/rosdistro/master/index-v4.yaml
 
-ENV ZENOH_BRIDGE_VERSION=1.3.2
+ENV ZENOH_BRIDGE_VERSION=1.5.0
 RUN cd /tmp; \
     if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
       curl -L -O https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/releases/download/${ZENOH_BRIDGE_VERSION}/zenoh-plugin-ros2dds-${ZENOH_BRIDGE_VERSION}-aarch64-unknown-linux-gnu-standalone.zip; \
@@ -120,16 +81,22 @@ RUN apt-get update && apt-get install -y nodejs sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+###########################################
+FROM lcas AS image_customisation
+COPY /root /
+#RUN apt-get update && apt-get install -y firefox && rm -rf /var/lib/apt/lists/*
+ENV CUSTOM_PORT=5801
+#ENV NO_FULL=1
+COPY lcas.png /lcas.png
+ENV WATERMARK_PNG=/lcas.png
+ENV WATERMARK_LOCATION=5
+ENV TITLE="L-CAS Desktop Container"
 
 ###########################################
-FROM lcas AS user
-USER ros
-ENV HOME=/home/ros
-WORKDIR ${HOME}
-RUN mkdir -p ${HOME}/.local/bin 
+FROM image_customisation AS user
 
-USER root
-COPY .gi? /tmp/gittemp/.git
+COPY .git /tmp/gittemp/.git
+RUN mkdir -p /opt/image
 RUN git -C /tmp/gittemp log -n 1 --pretty=format:"%H" > /opt/image/version
 
 RUN echo "# Welcome to the L-CAS Desktop Container.\n" > /opt/image/info.md; \
@@ -152,15 +119,4 @@ RUN echo "# Welcome to the L-CAS Desktop Container.\n" > /opt/image/info.md; \
     echo '```' >> /opt/image/info.md; \
     chmod -w /opt/image/info.md
 COPY README.md /opt/image/README.md
-    
-USER ros
-
-RUN mkdir -p ${HOME}/Desktop/ && \
-    ln -s /opt/image/info.md ${HOME}/Desktop/info.md && \
-    ln -s /opt/image/README.md ${HOME}/Desktop/README.md
-
-RUN mkdir -p ~/.config/rosdistro && echo "index_url: https://raw.github.com/LCAS/rosdistro/master/index-v4.yaml" > ~/.config/rosdistro/config.yaml
-
-ENV SHELL=/bin/bash
-
 

--- a/Dockerfile.selkies
+++ b/Dockerfile.selkies
@@ -83,9 +83,9 @@ RUN apt-get update && apt-get install -y nodejs sudo && \
 
 ###########################################
 FROM lcas AS image_customisation
-COPY /root /
+#COPY /root /
 #RUN apt-get update && apt-get install -y firefox && rm -rf /var/lib/apt/lists/*
-ENV CUSTOM_PORT=5801
+#ENV CUSTOM_PORT=5801
 #ENV NO_FULL=1
 COPY lcas.png /lcas.png
 ENV WATERMARK_PNG=/lcas.png

--- a/Dockerfile.selkies
+++ b/Dockerfile.selkies
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/selkies-project/nvidia-egl-desktop:24.04
+ARG BASE_IMAGE=ghcr.io/selkies-project/nvidia-egl-desktop:24.04-20250629090949
 
 ###########################################
 FROM ${BASE_IMAGE} AS base

--- a/Dockerfile.selkies
+++ b/Dockerfile.selkies
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ghcr.io/selkies-project/nvidia-egl-desktop:24.04-20250629090949
+ARG BASE_IMAGE=ghcr.io/linuxserver/baseimage-selkies:ubuntunoble
 
 ###########################################
 FROM ${BASE_IMAGE} AS base

--- a/Dockerfile.selkies
+++ b/Dockerfile.selkies
@@ -1,0 +1,166 @@
+ARG BASE_IMAGE=ghcr.io/selkies-project/nvidia-egl-desktop:24.04
+
+###########################################
+FROM ${BASE_IMAGE} AS base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install language
+RUN apt-get update ; \
+  apt-get upgrade -y && \
+  apt-get install -y --no-install-recommends \
+  locales \
+  && locale-gen en_US.UTF-8 \
+  && update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
+  && rm -rf /var/lib/apt/lists/*
+ENV LANG=en_US.UTF-8
+
+# Install timezone
+RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update ; \
+  apt-get install -y --no-install-recommends tzdata \
+  && dpkg-reconfigure --frontend noninteractive tzdata \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update; apt-get -y upgrade \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install common programs
+RUN apt-get update; apt-get install -y --no-install-recommends \
+    curl \
+    gnupg2 \
+    lsb-release \
+    git \
+    nano \
+    sudo \
+    python3-setuptools \
+    software-properties-common \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+# Prepare ROS2
+RUN add-apt-repository universe \
+  && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+
+################
+# Expose the nvidia driver to allow opengl 
+# Dependencies for glvnd and X11.
+################
+RUN apt-get update \
+ && apt-get install -y -qq --no-install-recommends \
+  libglvnd0 \
+  libgl1 \
+  libglx0 \
+  libegl1 \
+  libxext6 \
+  libx11-6 \
+  && rm -rf /var/lib/apt/lists/*
+
+# Env vars for the nvidia-container-runtime.
+ENV NVIDIA_VISIBLE_DEVICES=all
+# enable all capabilities for the container
+# Explained here: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/1.10.0/user-guide.html#driver-capabilities
+ENV NVIDIA_DRIVER_CAPABILITIES=all
+ENV QT_X11_NO_MITSHM=1
+
+
+ARG USERNAME=ros
+ARG USER_UID=1001
+ARG USER_GID=$USER_UID
+
+# Create a non-root user
+RUN groupadd --gid $USER_GID $USERNAME \
+  && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+  # Add sudo support for the non-root user
+  && apt-get update \
+  && apt-get install -y --no-install-recommends sudo \
+  && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+  && chmod 0440 /etc/sudoers.d/$USERNAME \
+  && rm -rf /var/lib/apt/lists/*
+
+
+###########################################
+FROM base AS lcas
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y lsb-release curl software-properties-common unzip apt-transport-https && \
+    rm -rf /var/lib/apt/lists/* 
+
+RUN sh -c 'echo "deb https://lcas.lincoln.ac.uk/apt/lcas $(lsb_release -sc) lcas" > /etc/apt/sources.list.d/lcas-latest.list' && \
+    curl -s https://lcas.lincoln.ac.uk/apt/repo_signing.gpg > /etc/apt/trusted.gpg.d/lcas-latest.gpg
+
+RUN mkdir -p /etc/ros/rosdep/sources.list.d/ && \
+    curl -o /etc/ros/rosdep/sources.list.d/20-default.list https://raw.githubusercontent.com/LCAS/rosdistro/master/rosdep/sources.list.d/20-default.list && \
+    curl -o /etc/ros/rosdep/sources.list.d/50-lcas.list https://raw.githubusercontent.com/LCAS/rosdistro/master/rosdep/sources.list.d/50-lcas.list
+
+ENV ROSDISTRO_INDEX_URL=https://raw.github.com/LCAS/rosdistro/master/index-v4.yaml
+
+ENV ZENOH_BRIDGE_VERSION=1.3.2
+RUN cd /tmp; \
+    if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+      curl -L -O https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/releases/download/${ZENOH_BRIDGE_VERSION}/zenoh-plugin-ros2dds-${ZENOH_BRIDGE_VERSION}-aarch64-unknown-linux-gnu-standalone.zip; \
+    else \
+      curl -L -O https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds/releases/download/${ZENOH_BRIDGE_VERSION}/zenoh-plugin-ros2dds-${ZENOH_BRIDGE_VERSION}-x86_64-unknown-linux-gnu-standalone.zip; \
+    fi; \
+    unzip zenoh-plugin-ros2dds-*.zip && \
+    mv zenoh-bridge-ros2dds /usr/local/bin/ && \
+    chmod +x /usr/local/bin/zenoh-bridge-ros2dds && \
+    ldconfig && \
+    rm -rf zenoh-*
+
+# install nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+RUN apt-get update && apt-get install -y nodejs sudo && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+
+###########################################
+FROM lcas AS user
+USER ros
+ENV HOME=/home/ros
+WORKDIR ${HOME}
+RUN mkdir -p ${HOME}/.local/bin 
+
+USER root
+COPY .gi? /tmp/gittemp/.git
+RUN git -C /tmp/gittemp log -n 1 --pretty=format:"%H" > /opt/image/version
+
+RUN echo "# Welcome to the L-CAS Desktop Container.\n" > /opt/image/info.md; \
+    echo "This is a Virtual Desktop provided by [L-CAS](https://lcas.lincoln.ac.uk/)." >> /opt/image/info.md; \
+    echo "\n" >> /opt/image/info.md; \
+    echo "*built from https://github.com/LCAS/ros-docker-images\n(commit: [\`$(cat /opt/image/version)\`](https://github.com/LCAS/ros-docker-images/tree/$(cat /opt/image/version)/)),\nprovided to you by [L-CAS](https://lcas.lincoln.ac.uk/).*" >> /opt/image/info.md; \
+    echo "\n" >> /opt/image/info.md; \
+    echo "## Installed Software\n" >> /opt/image/info.md; \
+    echo "The following software is installed:" >> /opt/image/info.md; \
+    echo "* The L-CAS ROS2 [apt repositories](https://lcas.lincoln.ac.uk/apt/lcas) are enabled." >> /opt/image/info.md; \
+    echo "* The L-CAS [rosdistro](https://github.com/LCAS/rosdistro) is enabled." >> /opt/image/info.md; \
+    echo "* The Zenoh ROS2 bridge \`zenoh-bridge-ros2dds\` (version: ${ZENOH_BRIDGE_VERSION})." >> /opt/image/info.md; \
+    echo "* Node.js (with npm) in version $(node --version)." >> /opt/image/info.md; \
+    echo "* password-less \`sudo\` to install more packages." >> /opt/image/info.md; \
+    echo "\n" >> /opt/image/info.md; \
+    echo "## Default Environment\n" >> /opt/image/info.md; \
+    echo "The following environment variables are set by default:" >> /opt/image/info.md; \
+    echo '```' >> /opt/image/info.md; \
+    env >> /opt/image/info.md; \
+    echo '```' >> /opt/image/info.md; \
+    chmod -w /opt/image/info.md
+COPY README.md /opt/image/README.md
+    
+USER ros
+
+RUN mkdir -p ${HOME}/Desktop/ && \
+    ln -s /opt/image/info.md ${HOME}/Desktop/info.md && \
+    ln -s /opt/image/README.md ${HOME}/Desktop/README.md
+
+RUN mkdir -p ~/.config/rosdistro && echo "index_url: https://raw.github.com/LCAS/rosdistro/master/index-v4.yaml" > ~/.config/rosdistro/config.yaml
+
+ENV SHELL=/bin/bash
+
+

--- a/compose-selkies.yaml
+++ b/compose-selkies.yaml
@@ -1,0 +1,30 @@
+services:
+  lcas_desktop:
+    #image: lscr.io/linuxserver/webtop:ubuntu-xfce
+    build:
+      context: .
+      dockerfile: Dockerfile.selkies
+      args:
+        BASE_IMAGE: lscr.io/linuxserver/webtop:ubuntu-xfce
+        ROS_DISTRO: jazzy
+    ports:
+      - "3000:3000"
+      - "3001:3001"
+    volumes:
+      # persist user's home
+      - user_home:/config
+      - /var/run/docker.sock:/var/run/docker.sock
+    shm_size: "1gb" #optional
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [compute,video,graphics,utility]
+    security_opt:
+      - seccomp:unconfined #optional
+
+volumes:
+  user_home:
+    name: ${COMPOSE_PROJECT_NAME}_lcas_desktop_user_${USER}


### PR DESCRIPTION
This pull request introduces support for building a new Docker image based on the `selkies-project/nvidia-egl-desktop:24.04` base, targeting enhanced NVIDIA GPU and ROS2 integration. The main changes include adding a new `Dockerfile.selkies`, updating the GitHub Actions workflow to build and push this new image, and improving flexibility in selecting Dockerfiles for different build targets.

**Docker build enhancements:**

* Added a new `Dockerfile.selkies` to build images from the `ghcr.io/selkies-project/nvidia-egl-desktop:24.04` base, including ROS2, NVIDIA GPU support, Zenoh ROS2 bridge, Node.js, and L-CAS customizations.
* Updated `.github/workflows/docker-build.yaml` to include the new Selkies-based image in the build matrix and allow specifying different Dockerfiles for each build target.

**Workflow improvements:**

* Modified the Docker build step in `.github/workflows/docker-build.yaml` to dynamically select the Dockerfile based on the matrix configuration, enabling multi-image builds from different Dockerfiles.